### PR TITLE
feat: quickstart for self-hosting and optimization

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,5 @@ Dockerfile
 compose.yaml
 .github
 .vscode
+*.md
+.env.example

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,5 @@ Dockerfile
 .dockerignore
 .env
 compose.yaml
+.github
+.vscode

--- a/.env.example
+++ b/.env.example
@@ -17,5 +17,5 @@ MONGO_INITDB_DATABASE=samayPolls
 # In production, NEXT_MONGODB_URI is the connection string
 # In development, if using Docker, NEXT_MONGODB_URI is mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@database:27017/${MONGO_INITDB_DATABASE}?authSource=admin
 # If you wish to use a local database, you can use mongodb://localhost:27017/samayPolls
-# Uncomment the line below and set NEXT_MONGODB_URI if you wish to use a connection string for an external database directly (like on Atlas)
-# NEXT_MONGODB_URI=
+# Set NEXT_MONGODB_URI if you wish to use a connection string for an external database directly (ex. Atlas)
+NEXT_MONGODB_URI=

--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,10 @@ MONGO_INITDB_ROOT_PASSWORD=samayPassword
 MONGO_INITDB_DATABASE=samayPolls
 
 # In production, NEXT_MONGODB_URI is the connection string
-# In development, if using Docker, NEXT_MONGODB_URI is mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@database:27017/${MONGO_INITDB_DATABASE}?authSource=admin
-# If you wish to use a local database, you can use mongodb://localhost:27017/samayPolls
+# In development, if using Docker, set:
+# NEXT_MONGODB_URI to mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@database:27017/${MONGO_INITDB_DATABASE}?authSource=admin
+# (remember to substitute the values for username, password and database correctly)
+# 
+# If you wish to use a local database, set NEXT_MONGODB_URI to mongodb://localhost:27017/samayPolls
 # Set NEXT_MONGODB_URI if you wish to use a connection string for an external database directly (ex. Atlas)
 NEXT_MONGODB_URI=

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: install node v12
+      - name: install node v22
         uses: actions/setup-node@v1
         with:
-          node-version: 12
-      - name: yarn install
-        run: yarn install
+          node-version: 22
+      - name: npm ci --omit=dev
+        run: npm ci --omit=dev
       - name: eslint
         uses: icrawl/action-eslint@v1
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,19 @@ FROM node:22-alpine AS builder
 
 WORKDIR /app
 
-COPY package*.json ./
-RUN npm install
+COPY package*.json .
+RUN npm ci --omit=dev
 
-COPY . .
+COPY pages pages
+COPY public public
+COPY src src
+COPY next.config.js .
+COPY tsconfig.json .
 
-ARG NEXT_MONGODB_URI
 ARG NEXT_PUBLIC_BASE_URL
 ARG NEXT_PUBLIC_ENCRYPTION_KEY
 ARG NEXT_PUBLIC_ENCRYPTION_IV
 
-ENV NEXT_MONGODB_URI=$NEXT_MONGODB_URI
 ENV NEXT_PUBLIC_BASE_URL=$NEXT_PUBLIC_BASE_URL
 ENV NEXT_PUBLIC_ENCRYPTION_KEY=$NEXT_PUBLIC_ENCRYPTION_KEY
 ENV NEXT_PUBLIC_ENCRYPTION_IV=$NEXT_PUBLIC_ENCRYPTION_IV
@@ -24,13 +26,11 @@ FROM node:22-alpine AS runner
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm install --omit=dev
+RUN npm ci --omit=dev --prefer-offline
 
 COPY --from=builder /app/.next .next
 COPY --from=builder /app/public public
-COPY --from=builder /app/package.json .
 COPY --from=builder /app/next.config.js .
-COPY --from=builder /app/tsconfig.json .
 
 EXPOSE 3000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 
 WORKDIR /app
 
@@ -19,7 +19,7 @@ ENV NEXT_PUBLIC_ENCRYPTION_IV=$NEXT_PUBLIC_ENCRYPTION_IV
 
 RUN npm run build
 
-FROM node:20-alpine
+FROM node:22-alpine AS runner
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -53,28 +53,17 @@ If you have suggestions for how Samay could be improved or want to report an iss
 
 ### Docker
 
-We have an experimental Docker Compose file that can be used for self-hosting without need for an external database on MongoDB Atlas or other provider. To proceed with self-hosting using Docker Compose:
+We have an experimental quickstart script that can be used to self-host using Docker Compose in less than a minute.
 
-1. Clone the repository.
+To get started, run the command:
 
-   ```shell
-   git clone https://github.com/anandbaburajan/samay
-   cd samay
-   ```
+```shell
+sh -c $("curl -fsSL https://raw.githubusercontent.com/anandbaburajan/samay/main/quickstart.sh")
+```
 
-2. Populate the environment variables based on `.env.example` file based on the instructions provided in it.
+Enter your frontend URL and MongoDB connection string.
 
-   ```shell
-   cp .env.example .env
-   ```
-
-3. Start the cluster after setting the needed values.
-
-   ```shell
-   docker compose up --build
-   ```
-
-The web app can be accessed at http://localhost:3000.
+Once the cluster starts, the web app can be accessed at the URL you have defined.
 
 > [!TIP]
 >
@@ -87,7 +76,7 @@ The web app can be accessed at http://localhost:3000.
 
 > [!TIP]
 >
-> You may wish to use an external database (on Atlas), for which you can remove the `mongo` section in `compose.yaml` and define `NEXT_MONGODB_URI` with the connection string to the external database.
+> You may wish to use an external database (on Atlas), for which you can remove the `database` service in `compose.yaml` and define `NEXT_MONGODB_URI` with the connection string to the external database.
 
 ### Vercel and MongoDB Atlas
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,7 +5,6 @@ services:
       dockerfile: Dockerfile
       args:
         # Change this value to the connection string if not using MongoDB container
-        NEXT_MONGODB_URI: mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@database:27017/${MONGO_INITDB_DATABASE}?authSource=admin
         NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL}
         NEXT_PUBLIC_ENCRYPTION_KEY: ${NEXT_PUBLIC_ENCRYPTION_KEY}
         NEXT_PUBLIC_ENCRYPTION_IV: ${NEXT_PUBLIC_ENCRYPTION_IV}

--- a/compose.yaml
+++ b/compose.yaml
@@ -25,9 +25,6 @@ services:
     restart: unless-stopped
     env_file:
       - .env
-    environment:
-      # Change this value to the connection string if not using MongoDB container
-      NEXT_MONGODB_URI: mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@database:27017/${MONGO_INITDB_DATABASE}?authSource=admin
     networks:
       - samay-network
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,9 +10,18 @@ services:
         NEXT_PUBLIC_ENCRYPTION_KEY: ${NEXT_PUBLIC_ENCRYPTION_KEY}
         NEXT_PUBLIC_ENCRYPTION_IV: ${NEXT_PUBLIC_ENCRYPTION_IV}
     ports:
+      # Update the host port if another port is to be used 
       - 3000:3000
     depends_on:
-      - database
+      database:
+        condition: service_healthy
+    healthcheck:
+      # Update the host port if another port is to be used
+      test: ["CMD", "wget", "--spider", "-q", "http://0.0.0.0:3000/api/ping"]
+      start_period: 5s
+      interval: 60s
+      timeout: 5s
+      retries: 3
     restart: unless-stopped
     env_file:
       - .env
@@ -31,6 +40,12 @@ services:
       - .env
     networks:
       - samay-network
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping')"]
+      start_period: 40s
+      interval: 30s
+      timeout: 5s
+      retries: 3
 
 volumes:
   samay-data:

--- a/pages/api/ping.ts
+++ b/pages/api/ping.ts
@@ -1,6 +1,6 @@
+import mongoose from "mongoose";
 import { NextApiRequest, NextApiResponse } from "next";
 import connectToDatabase from "../../src/utils/db";
-import mongoose from "mongoose";
 
 export default async (
   req: NextApiRequest,

--- a/pages/api/ping.ts
+++ b/pages/api/ping.ts
@@ -1,0 +1,19 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import connectToDatabase from "../../src/utils/db";
+import mongoose from "mongoose";
+
+export default async (
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> => {
+    try {
+        await connectToDatabase();
+        const result = await mongoose.connection.db.admin().ping();
+        if (result.ok) {
+            return res.status(200).json(result);
+        }
+        return res.status(500).json({ ok: 0 });
+    } catch (err) {
+        return res.status(500).json({ ok: 0 });
+    }
+};

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+# Checking for dependencies on system
+if ! command -v git &> /dev/null; then
+  printf "ERROR: Please install Git before running the script.\n"
+  exit 1
+fi
+
+if ! command -v openssl &> /dev/null; then
+  printf "ERROR: Please install OpenSSL before running the script. It is needed for generation of encryption key and IV.\n"
+  exit 1
+fi
+
+compose_ver=""
+if command -v docker &> /dev/null; then
+    compose_ver=`docker compose version --short 2>/dev/null || echo`
+fi
+
+if test -z "$compose_ver"
+then
+    printf "ERROR: Please install Docker Compose before running this script.\n"
+    exit 1
+fi
+
+compose_ver_maj=`echo "$compose_ver" | cut -d . -f 1`
+
+if test \( "$compose_ver_maj" -lt 2 \)
+then
+    printf "ERROR: You need Docker Compose version 2 for running this script.\n"
+    exit 1
+fi
+
+# Check if 'samay' directory is present on the system
+if test -d samay ; then
+  printf "Directory 'samay' already exists. To start the cluster: \n\n"
+  printf "  \033[1m $ cd samay && docker compose up --build\033[0m\n\n"
+  exit 1
+fi
+
+# Helper function for password generation
+gen_password() {
+  password=`head -c 12 /dev/urandom | base64 | tr -d '=+' | cut -c1-16`
+  echo "$password"
+}
+
+
+# Clone the project
+git clone https://github.com/anandbaburajan/samay
+cd samay
+cp .env.example .env
+
+
+# Encryption key and IV for encryption and decryption of data
+encryption_key=`openssl rand -hex 16`
+encryption_iv=`openssl rand -hex 8`
+
+# Variables to be used for environment variable substitution
+frontend_url=http://localhost:3000
+mongo_user=samay
+mongo_pw=`gen_password`
+mongo_db=samayPolls
+mongo_uri=mongodb://${mongo_user}:${mongo_pw}@database:27017/${mongo_db}?authSource=admin
+
+# Get values for frontend and connection string from end user
+read -p "Enter frontend URL (default: http://localhost:3000): " frontend_uri
+read -p "Enter MongoDB connection string (leave it empty for default connection string): " mongo_uri
+
+if [ -n "$frontend_uri" ]; then
+  if [[ "$frontend_uri" == http://* || "$frontend_uri" == https://* ]]; then
+    frontend_url=$frontend_uri
+  else
+    printf "ERROR: frontend URL must start with http:// or https://"
+    exit 1
+  fi
+fi
+
+if [ -n "$mongo_uri" ]; then
+  if [[ "$mongo_uri" == mongodb://* || "$mongo_uri" == mongodb+srv://* ]]; then
+    frontend_url=$frontend_url
+  else
+    printf "ERROR: MongoDB connection string must start with mongodb:// or mongodb+srv://"
+    exit 1
+  fi
+fi
+
+# Replace values in the copied .env file to make sure the cluster uses the correct values
+sed -i "s|^NEXT_PUBLIC_BASE_URL=.*|NEXT_PUBLIC_BASE_URL=$frontend_url|" .env
+sed -i "s|^NEXT_MONGODB_URI=.*|NEXT_MONGODB_URI=$mongo_uri|" .env
+sed -i "s|^NEXT_PUBLIC_ENCRYPTION_KEY=.*|NEXT_PUBLIC_ENCRYPTION_KEY=$encryption_key|" .env
+sed -i "s|^NEXT_PUBLIC_ENCRYPTION_IV=.*|NEXT_PUBLIC_ENCRYPTION_IV=$encryption_iv|" .env
+sed -i "s|^MONGO_INITDB_ROOT_PASSWORD=.*|MONGO_INITDB_ROOT_PASSWORD=$mongo_pw|" .env
+
+# Starting cluster
+printf "\033[1mCreating cluster...\n\n"
+
+sleep 1
+
+docker compose up --build -d
+
+sleep 1
+
+printf "\033[1mYou should be able to access your web app at $frontend_url\n"


### PR DESCRIPTION
# Description

This PR adds support for self-hosting with Docker with a quickstart script that automatically generates credentials, encryption key and IV and spins up a cluster while prompting for connection string and frontend URL for easier onboarding as opposed to set up proposed in #218. The documentation is updated to reflect this change.

Furthermore, health check has been added to ensure reliability of the setup and Docker image has been updated to remove redundancy and updated to Node 22 after testing.

# Tests

- [x] I have tested the script and Compose setup locally

# Future considerations

- The Docker image size can be reduced by usage of yarn or pnpm by enabling corepack, this will require regeneration of lock files. However, since dependencies are outdated, it may pose issues during migration and requires major refactor (to handle Jumbotron's removal, linting related deprecations, etc.)
- Dedicated documentation to reduce information overload with README and to handle the nuances of self-hosting will help.